### PR TITLE
[#166791583] Connect to database using default postgres env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ IO onboarding portal webapp for public administrations
 
 ### Environment variables
 
-The application uses some Environment variables; if they are not set, the app falls back to default values.
-The table below describes all the Environment variables.
+The table below describes all the Environment variables needed by the application.
 
-| Variable name       | Description                                       | type   | default value |
-|---------------------|---------------------------------------------------|--------|---------------|
-| POSTGRES_HOST       | The host name used in postgres connection string  | string | `localhost`   |
-| POSTGRES_PASSWORD   | The password used in postgres connection string   | string | `password`    |
-| POSTGRES_USER       | The user used in postgres connection string       | string | `postgres`    |
+| Variable name       | Description                                       | type   |
+|---------------------|---------------------------------------------------|--------|
+| PGHOST              | The name of postgres server host to connect to    | string |
+| PGPASSWORD          | The password used to connect to postgres server   | string |
+| PGUSER              | PostgreSQL user name to connect as                | string |
+| PGDATABASE          | The database name                                 | string |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,13 +6,15 @@ services:
       context: ./
       dockerfile: dockerfile
     environment:
-      POSTGRES_PASSWORD: password
-      POSTGRES_USER: postgres
-      POSTGRES_HOST: database
+      PGDATABASE: postgres
+      PGPASSWORD: password
+      PGUSER: postgres
+      PGHOST: database
     ports:
       - "3000:3000"
     depends_on:
       - database
+    restart: always
 
   database:
     container_name: postgresql

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,14 +5,7 @@ import { Pool } from "pg";
 
 import { log } from "./utils/logger";
 
-const dbParams = {
-  host: process.env.POSTGRES_HOST || "localhost",
-  password: process.env.POSTGRES_PASSWORD || "password",
-  user: process.env.POSTGRES_USER || "postgres"
-};
-const postgres = new Pool({
-  connectionString: `postgres://${dbParams.user}:${dbParams.password}@${dbParams.host}/postgres`
-});
+const postgres = new Pool();
 
 function createConnection(db: Pool): Promise<void> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
This PR refactors the postgres Pool creation: instead of using a connections string based on custom environment variables, the Pool now gets the connection attributes from the default postgres environment variables.