### PR TITLE
[#166979747] Change database name in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       context: ./
       dockerfile: dockerfile
     environment:
-      PGDATABASE: postgres
+      PGDATABASE: db
       PGPASSWORD: password
       PGUSER: postgres
       PGHOST: database
@@ -22,5 +22,6 @@ services:
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres
+      POSTGRES_DB: db
     ports:
       - "5432:5432"


### PR DESCRIPTION
This PR changes the database name in `docker-compe.yaml` file in order not to use postgres default db.